### PR TITLE
Update namespaces for RuboCop 0.78

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -9,16 +9,16 @@ Layout/MultilineMethodCallIndentation:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
 
 Layout/SpaceInsideHashLiteralBraces:
@@ -27,11 +27,11 @@ Layout/SpaceInsideHashLiteralBraces:
 Layout/MultilineMethodDefinitionBraceLayout:
   EnforcedStyle: new_line
 
+Layout/LineLength:
+  Max: 120
+
 Style/EmptyElse:
   EnforcedStyle: empty
 
 Style/Documentation:
   Enabled: no
-
-Metrics/LineLength:
-  Max: 120

--- a/rubocop-salemove.gemspec
+++ b/rubocop-salemove.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/salemove/rubocop-salemove'
   s.license     = 'MIT'
 
-  s.add_dependency 'rubocop', '~> 0.68'
+  s.add_dependency 'rubocop', '~> 0.78'
   s.add_dependency 'rubocop-rspec', '~> 1.15'
 end

--- a/rubocop-salemove.gemspec
+++ b/rubocop-salemove.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-salemove'
-  s.version     = '0.0.3'
+  s.version     = '0.0.4'
   s.date        = '2017-05-04'
   s.summary     = 'RuboCop SaleMove'
   s.description = 'Shared RuboCop configuration for SaleMove projects'


### PR DESCRIPTION
Last 10 minor versions of RuboCop have introduced multiple breaking
changes by renaming the in-use namespaces and also added couple of
deprecation warnings. This commit addresses all of those and bumps
the gem version to 0.0.4

Related `rubocop` changelog entry - https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes-11