### PR TITLE
Upgrade rubocop and rubocop-rspec versions

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,6 +3,7 @@ require: rubocop-rspec
 AllCops:
   DisplayCopNames: yes
   NewCops: enable
+  SuggestExtensions: false
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/rubocop-salemove.gemspec
+++ b/rubocop-salemove.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/salemove/rubocop-salemove'
   s.license     = 'MIT'
 
-  s.add_dependency 'rubocop', '~> 0.82'
-  s.add_dependency 'rubocop-rspec', '~> 1.15'
+  s.add_dependency 'rubocop', '~> 1.16'
+  s.add_dependency 'rubocop-rspec', '~> 2.4'
 end

--- a/rubocop-salemove.gemspec
+++ b/rubocop-salemove.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-salemove'
-  s.version     = '0.0.5'
+  s.version     = '1.0.0'
   s.date        = '2017-05-04'
   s.summary     = 'RuboCop SaleMove'
   s.description = 'Shared RuboCop configuration for SaleMove projects'


### PR DESCRIPTION
New major version was released 2020 November. There doesn't seem to be many
breaking changes.

https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#100-2020-10-21