### PR TITLE
Update rubocop rules

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -38,8 +38,32 @@ Style/EmptyElse:
 Style/Documentation:
   Enabled: no
 
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/BlockLength:
+  Enabled: false
+
 RSpec/NoExpectationExample:
   Enabled: no
 
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/IndexedLet:
+  Max: 2

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,12 +1,27 @@
 require: rubocop-rspec
 
 AllCops:
-  DisplayCopNames: yes
+  DisplayCopNames: true
   NewCops: enable
   SuggestExtensions: false
 
+Layout/FirstArgumentIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+Layout/LineLength:
+  Max: 120
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: new_line
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
@@ -14,56 +29,44 @@ Layout/MultilineOperationIndentation:
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
-
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-
-Layout/FirstArgumentIndentation:
-  EnforcedStyle: consistent
-
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
-
-Layout/MultilineMethodDefinitionBraceLayout:
-  EnforcedStyle: new_line
-
-Layout/LineLength:
-  Max: 120
-
-Style/EmptyElse:
-  EnforcedStyle: empty
-
-Style/Documentation:
-  Enabled: no
-
-Naming/MemoizedInstanceVariableName:
-  EnforcedStyleForLeadingUnderscores: optional
-
-Metrics/MethodLength:
-  Max: 15
 
 Metrics/BlockLength:
   Enabled: false
 
-RSpec/NoExpectationExample:
-  Enabled: no
+Metrics/MethodLength:
+  Max: 15
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyElse:
+  EnforcedStyle: empty
 
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/MultipleMemoizedHelpers:
+RSpec/IndexedLet:
+  Max: 2
+
+RSpec/MessageSpies:
   Enabled: false
 
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 4
 
-RSpec/MessageSpies:
+RSpec/NoExpectationExample:
   Enabled: false
-
-RSpec/IndexedLet:
-  Max: 2

--- a/rubocop-salemove.gemspec
+++ b/rubocop-salemove.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-salemove'
-  s.version     = '1.1.0'
+  s.version     = '1.2.0'
   s.date        = '2017-05-04'
   s.summary     = 'RuboCop SaleMove'
   s.description = 'Shared RuboCop configuration for SaleMove projects'


### PR DESCRIPTION
Make the default configuration a bit more lenient in order to enforce a more consistent style across the organization. If it is too strict, then rules will be disabled or modified separately in every repository. Can create confusion or discomfort when working on multiple repos with wildly different rulesets.