### PR TITLE
Update rubocop version.

### DIFF
--- a/rubocop-salemove.gemspec
+++ b/rubocop-salemove.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'rubocop-salemove'
-  s.version     = '1.3.0'
+  s.version     = '1.4.0'
   s.date        = '2017-05-04'
   s.summary     = 'RuboCop SaleMove'
   s.description = 'Shared RuboCop configuration for SaleMove projects'
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/salemove/rubocop-salemove'
   s.license     = 'MIT'
 
-  s.add_dependency 'rubocop', '~> 1.36'
+  s.add_dependency 'rubocop', '~> 1.66'
   s.add_dependency 'rubocop-rspec', ['>= 2.13', '< 4.0']
 end


### PR DESCRIPTION
Until rubocop version 1.66 it had dependency for rexml. Rexml versions before 3.3.9 has ReDoS vulnerability. https://www.cve.org/CVERecord?id=CVE-2024-49761

In rubocop version 1.66 dependency for rexml was removed https://github.com/rubocop/rubocop/releases/tag/v1.66.0

Also pumping version